### PR TITLE
Knife-throwing Mini-game V1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,16 @@ export_presets.cfg
 .mono/
 data_*/
 mono_crash.*.json
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/jest-quest/scenes/main_scenes/game.tscn
+++ b/jest-quest/scenes/main_scenes/game.tscn
@@ -7,6 +7,7 @@
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 layer = -10
+visible = false
 
 [node name="TextureRect" type="TextureRect" parent="CanvasLayer"]
 z_index = -10

--- a/jest-quest/scenes/main_scenes/game.tscn
+++ b/jest-quest/scenes/main_scenes/game.tscn
@@ -7,7 +7,6 @@
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 layer = -10
-visible = false
 
 [node name="TextureRect" type="TextureRect" parent="CanvasLayer"]
 z_index = -10

--- a/jest-quest/scenes/mini_games/knife_throwing/knife_throwing.tscn
+++ b/jest-quest/scenes/mini_games/knife_throwing/knife_throwing.tscn
@@ -1,0 +1,67 @@
+[gd_scene load_steps=5 format=3 uid="uid://breroar7ddmc8"]
+
+[ext_resource type="Script" path="res://scripts/mini_games/knife_throwing/knife_throwing.gd" id="1_g8mqh"]
+[ext_resource type="PackedScene" uid="uid://cxny6ekgbhs4k" path="res://scenes/mini_games/knife_throwing/range_bar.tscn" id="1_q3173"]
+
+[sub_resource type="Curve2D" id="Curve2D_trhui"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, 280, 544, 0, 0, 0, 0, 872, 544)
+}
+point_count = 2
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_xjvk2"]
+
+[node name="KnifeThrowing" type="Node2D"]
+script = ExtResource("1_g8mqh")
+
+[node name="AimPath" type="Path2D" parent="."]
+curve = SubResource("Curve2D_trhui")
+
+[node name="PathFollow" type="PathFollow2D" parent="AimPath"]
+position = Vector2(280, 544)
+loop = false
+
+[node name="AimBar" type="Area2D" parent="AimPath/PathFollow"]
+z_index = 4
+position = Vector2(944, 544)
+rotation = 3.14159
+
+[node name="CollisionShape" type="CollisionShape2D" parent="AimPath/PathFollow/AimBar"]
+position = Vector2(944, 544)
+scale = Vector2(0.3, 4)
+shape = SubResource("RectangleShape2D_xjvk2")
+
+[node name="ColorRect" type="ColorRect" parent="AimPath/PathFollow/AimBar/CollisionShape"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -10.0
+offset_top = -10.0
+offset_right = 10.0
+offset_bottom = 10.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Perfect" parent="." instance=ExtResource("1_q3173")]
+z_index = 3
+position = Vector2(576, 544)
+width_scale = 0.1
+color = Color(0.298031, 0.694352, 7.70092e-07, 1)
+
+[node name="Good" parent="." instance=ExtResource("1_q3173")]
+z_index = 2
+position = Vector2(576, 544)
+width_scale = 0.4
+color = Color(0.887235, 0.453811, 5.77569e-07, 1)
+
+[node name="Average" parent="." instance=ExtResource("1_q3173")]
+z_index = 1
+position = Vector2(576, 544)
+width_scale = 0.7
+color = Color(0.668524, 0.592517, 0, 1)
+
+[node name="Missed" parent="." instance=ExtResource("1_q3173")]
+position = Vector2(576, 544)
+color = Color(0.67451, 0.67451, 0.67451, 1)

--- a/jest-quest/scenes/mini_games/knife_throwing/knife_throwing.tscn
+++ b/jest-quest/scenes/mini_games/knife_throwing/knife_throwing.tscn
@@ -12,6 +12,7 @@ point_count = 2
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_xjvk2"]
 
 [node name="KnifeThrowing" type="Node2D"]
+position = Vector2(-576, -300)
 script = ExtResource("1_g8mqh")
 
 [node name="AimPath" type="Path2D" parent="."]

--- a/jest-quest/scenes/mini_games/knife_throwing/knife_throwing.tscn
+++ b/jest-quest/scenes/mini_games/knife_throwing/knife_throwing.tscn
@@ -5,9 +5,9 @@
 
 [sub_resource type="Curve2D" id="Curve2D_trhui"]
 _data = {
-"points": PackedVector2Array(0, 0, 0, 0, 280, 544, 0, 0, 0, 0, 872, 544)
+"points": PackedVector2Array(0, 0, 0, 0, 280, 544, 0, 0, 0, 0, 416.51, 543.229, 0, 0, 0, 0, 609.844, 544.497, 0, 0, 0, 0, 872, 544)
 }
-point_count = 2
+point_count = 4
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_xjvk2"]
 
@@ -15,19 +15,18 @@ point_count = 2
 script = ExtResource("1_g8mqh")
 
 [node name="AimPath" type="Path2D" parent="."]
+position = Vector2(-578, -294)
 curve = SubResource("Curve2D_trhui")
 
 [node name="PathFollow" type="PathFollow2D" parent="AimPath"]
 position = Vector2(280, 544)
+rotation = -0.00564651
 loop = false
 
 [node name="AimBar" type="Area2D" parent="AimPath/PathFollow"]
 z_index = 4
-position = Vector2(944, 544)
-rotation = 3.14159
 
 [node name="CollisionShape" type="CollisionShape2D" parent="AimPath/PathFollow/AimBar"]
-position = Vector2(944, 544)
 scale = Vector2(0.3, 4)
 shape = SubResource("RectangleShape2D_xjvk2")
 
@@ -43,25 +42,26 @@ offset_right = 10.0
 offset_bottom = 10.0
 grow_horizontal = 2
 grow_vertical = 2
+metadata/_edit_use_anchors_ = true
 
 [node name="Perfect" parent="." instance=ExtResource("1_q3173")]
 z_index = 3
-position = Vector2(576, 544)
+position = Vector2(0, 248)
 width_scale = 0.1
 color = Color(0.298031, 0.694352, 7.70092e-07, 1)
 
 [node name="Good" parent="." instance=ExtResource("1_q3173")]
 z_index = 2
-position = Vector2(576, 544)
+position = Vector2(0, 248)
 width_scale = 0.4
 color = Color(0.887235, 0.453811, 5.77569e-07, 1)
 
 [node name="Average" parent="." instance=ExtResource("1_q3173")]
 z_index = 1
-position = Vector2(576, 544)
+position = Vector2(0, 248)
 width_scale = 0.7
 color = Color(0.668524, 0.592517, 0, 1)
 
 [node name="Missed" parent="." instance=ExtResource("1_q3173")]
-position = Vector2(576, 544)
+position = Vector2(0, 248)
 color = Color(0.67451, 0.67451, 0.67451, 1)

--- a/jest-quest/scenes/mini_games/knife_throwing/range_bar.tscn
+++ b/jest-quest/scenes/mini_games/knife_throwing/range_bar.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=3 uid="uid://cxny6ekgbhs4k"]
+
+[ext_resource type="Script" path="res://scripts/mini_games/knife_throwing/range_bar.gd" id="1_ma2en"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_5gp8y"]
+
+[node name="RangeBar" type="Area2D"]
+script = ExtResource("1_ma2en")
+
+[node name="CollisionShape" type="CollisionShape2D" parent="."]
+scale = Vector2(30, 3)
+shape = SubResource("RectangleShape2D_5gp8y")
+debug_color = Color(0, 0.6, 0.701961, 0.419608)
+
+[node name="Color" type="ColorRect" parent="CollisionShape"]
+offset_left = -10.0
+offset_top = -10.0
+offset_right = 10.0
+offset_bottom = 10.0

--- a/jest-quest/scripts/managers/game_manager.gd
+++ b/jest-quest/scripts/managers/game_manager.gd
@@ -4,7 +4,8 @@ var score = 0
 var mini_games : Array = []
 var rng = RandomNumberGenerator.new()
 
-@onready var juggling = preload("res://scenes/mini_games/juggling.tscn")
+const juggling = preload("res://scenes/mini_games/juggling.tscn")
+const knife_throwing = preload("res://scenes/mini_games/knife_throwing/knife_throwing.tscn")
 
 func _ready():
     mini_games.append(juggling)

--- a/jest-quest/scripts/managers/game_manager.gd
+++ b/jest-quest/scripts/managers/game_manager.gd
@@ -4,10 +4,12 @@ var score = 0
 var mini_games : Array = []
 var rng = RandomNumberGenerator.new()
 
-@onready var juggling = preload("res://scenes/mini_games/juggling.tscn")
+const juggling = preload("res://scenes/mini_games/juggling.tscn")
+const knife_throwing = preload("res://scenes/mini_games/knife_throwing/knife_throwing.tscn")
 
 func _ready():
     mini_games.append(juggling)
+    mini_games.append(knife_throwing)
     instantiate_random_scene()
 
 

--- a/jest-quest/scripts/managers/game_manager.gd
+++ b/jest-quest/scripts/managers/game_manager.gd
@@ -8,29 +8,30 @@ const juggling = preload("res://scenes/mini_games/juggling.tscn")
 const knife_throwing = preload("res://scenes/mini_games/knife_throwing/knife_throwing.tscn")
 
 func _ready():
-    mini_games.append(juggling)
-    instantiate_random_scene()
+	mini_games.append(juggling)
+	mini_games.append(knife_throwing)
+	instantiate_random_scene()
 
 
 func instantiate_random_scene():
-    if mini_games.size() > 0:
-        var random_index : int = rng.randi_range(0, mini_games.size() - 1)
-        var instance: Node = mini_games[random_index].instantiate()
-        instance.connect("failure", self.on_failure)
-        instance.connect("finish", self.on_finished)
-        add_child(instance)
+	if mini_games.size() > 0:
+		var random_index : int = rng.randi_range(0, mini_games.size() - 1)
+		var instance: Node = mini_games[random_index].instantiate()
+		instance.connect("failure", self.on_failure)
+		instance.connect("finish", self.on_finished)
+		add_child(instance)
 
 
 func on_failure():
-    score -= 1
-    print("MAIN SCORE FAILURE: " + str(score))
+	score -= 1
+	print("MAIN SCORE FAILURE: " + str(score))
 
 
 func on_finished():
-    score += 1
-    print("MAIN SCORE SUCCESS: " + str(score))
-    var current_scene : Node = get_child(0)
-    current_scene.disconnect("failure", self.on_failure)
-    current_scene.disconnect("finish", self.on_finished)
-    current_scene.queue_free()
-    instantiate_random_scene()
+	score += 1
+	print("MAIN SCORE SUCCESS: " + str(score))
+	var current_scene : Node = get_child(0)
+	current_scene.disconnect("failure", self.on_failure)
+	current_scene.disconnect("finish", self.on_finished)
+	current_scene.queue_free()
+	instantiate_random_scene()

--- a/jest-quest/scripts/managers/game_manager.gd
+++ b/jest-quest/scripts/managers/game_manager.gd
@@ -8,9 +8,9 @@ const juggling = preload("res://scenes/mini_games/juggling.tscn")
 const knife_throwing = preload("res://scenes/mini_games/knife_throwing/knife_throwing.tscn")
 
 func _ready():
-    mini_games.append(juggling)
-    mini_games.append(knife_throwing)
-    instantiate_random_scene()
+	mini_games.append(juggling)
+	mini_games.append(knife_throwing)
+	instantiate_random_scene()
 
 
 func instantiate_random_scene():

--- a/jest-quest/scripts/mini_games/juggling.gd
+++ b/jest-quest/scripts/mini_games/juggling.gd
@@ -5,27 +5,27 @@ var clickable : bool = false
 var score = 0
 
 func _process(_delta):
-    if clickable:
-        if Input.is_action_just_pressed("LeftClick"):
-            has_clicked = true
-            score += 1
-            print("Hit! = " + str(score))
-    else:
-        if Input.is_action_just_pressed("LeftClick"):
-            failed()
-            score -= 1
-            print("Missclick = " + str(score))
+	if clickable:
+		if Input.is_action_just_pressed("LeftClick"):
+			has_clicked = true
+			score += 1
+			print("Hit! = " + str(score))
+	else:
+		if Input.is_action_just_pressed("LeftClick"):
+			failed()
+			score -= 1
+			print("Missclick = " + str(score))
 
 
 func toggle_clickable():
-    if not clickable:
-        has_clicked = false
-        clickable = true
-    else:
-        if has_clicked:
-            clickable = false
-        else:
-            failed()
-            score -= 1
-            clickable = false
-            print("Missed = " + str(score))
+	if not clickable:
+		has_clicked = false
+		clickable = true
+	else:
+		if has_clicked:
+			clickable = false
+		else:
+			failed()
+			score -= 1
+			clickable = false
+			print("Missed = " + str(score))

--- a/jest-quest/scripts/mini_games/knife_throwing/knife_throwing.gd
+++ b/jest-quest/scripts/mini_games/knife_throwing/knife_throwing.gd
@@ -1,0 +1,18 @@
+extends "res://scripts/mini_games/mini_game.gd"
+
+var game_name = "Knife-throwing"
+var game_description = "Throw knives at the target. The closer to the center, the more points you get."
+
+@onready var aim_bar_path = get_node("AimPath/PathFollow")
+
+@export var speed_multiplier = 1.0
+var speed = 0.2
+
+func _process(delta) -> void:
+    # Check how far along the path the aim bar is
+    var progress_ratio = aim_bar_path.progress_ratio
+    if progress_ratio >= 1.0 or progress_ratio <= 0.0:
+        # Change the direction if we have hit the start or end of the path
+        speed *= -1.0
+    # Keep moving the aim bar along the path
+    aim_bar_path.progress_ratio += speed * speed_multiplier * delta

--- a/jest-quest/scripts/mini_games/knife_throwing/knife_throwing.gd
+++ b/jest-quest/scripts/mini_games/knife_throwing/knife_throwing.gd
@@ -3,12 +3,22 @@ extends "res://scripts/mini_games/mini_game.gd"
 var game_name = "Knife-throwing"
 var game_description = "Throw knives at the target. The closer to the center, the more points you get."
 
+# Mini-game State
+var current_round = 1
+const MAX_ROUNDS = 5
+var n_missed = 0
+const MAX_MISSED = 3
+# TODO: eventually remove this in favor of updating the gamestate score
+var score = 0
+
 # Aim Bar
 @onready var aim_bar = get_node('AimPath/PathFollow/AimBar')
 @onready var aim_bar_path = get_node("AimPath/PathFollow")
 
 @export var speed_multiplier = 1.0
 var speed = 0.2
+var did_click = false
+
 enum RANGES {MISSED = 0, AVERAGE, GOOD, PERFECT}
 @onready var missed = get_node("Missed")
 @onready var average = get_node("Average")
@@ -17,7 +27,21 @@ enum RANGES {MISSED = 0, AVERAGE, GOOD, PERFECT}
 @onready var current_range = RANGES.MISSED
 
 
+func _ready() -> void:
+    reset()
+
+
+# Reset the state of the mini-game
+func reset() -> void:
+    current_round = 1
+    n_missed = 0
+    score = 0
+
+
 func _process(delta) -> void:
+    # Check if user did click, return early if true
+    if did_click: return
+
     # Check how far along the path the aim bar is
     var progress_ratio = aim_bar_path.progress_ratio
     if progress_ratio >= 1.0 or progress_ratio <= 0.0:
@@ -25,6 +49,37 @@ func _process(delta) -> void:
         speed *= -1.0
     # Keep moving the aim bar along the path
     aim_bar_path.progress_ratio += speed * speed_multiplier * delta
+
+
+func _unhandled_input(event) -> void:
+    # Respond to mouse clicks anywhere in the window except for buttons
+    if event.is_action_pressed("left_mouse_button"):
+        did_click = true
+        var points_won = get_overlapping_range()
+
+        # TODO: remove this in favor of waiting on the animation
+
+
+        # Either update score or increased the missed count
+        if points_won == 0:
+            # TODO: Pause for a second to show some poor knife-throwing animation
+            # TODO: play sfx
+            n_missed += 1
+            if n_missed == MAX_MISSED:
+                game_lost()
+                return
+        else:
+            # TODO: Pause for a second to show some knife-throwing animation
+            # and a change to the score
+            # TODO: play sfx
+            # TODO: Eventually include a mood meter score multiplier?
+            score += points_won
+
+        # Go to the next round
+        if current_round == MAX_ROUNDS:
+            game_won()
+        else:
+            next_round()
 
 
 # Returns the range that the aim bar is overlapping
@@ -38,3 +93,24 @@ func get_overlapping_range() -> RANGES:
         return RANGES.AVERAGE
     return RANGES.MISSED
 
+
+func next_round() -> void:
+    # Increase the round number
+    current_round += 1
+    # Reset the aim bar position
+    # TODO: reset to either start or end, chosen at random
+    aim_bar_path.progress_ratio = 0.0
+    # Update the ranges
+    did_click = false
+
+
+func game_lost() -> void:
+    # Display game lost animation
+    print("you lost :(")
+    failed()
+
+
+func game_won() -> void:
+    # Display game won animation
+    print("you won!")
+    finished()

--- a/jest-quest/scripts/mini_games/knife_throwing/knife_throwing.gd
+++ b/jest-quest/scripts/mini_games/knife_throwing/knife_throwing.gd
@@ -1,5 +1,6 @@
 extends "res://scripts/mini_games/mini_game.gd"
 
+# Mini-game Details
 var game_name = "Knife-throwing"
 var game_description = "Throw knives at the target. The closer to the center, the more points you get."
 
@@ -15,10 +16,12 @@ var score = 0
 @onready var aim_bar = get_node('AimPath/PathFollow/AimBar')
 @onready var aim_bar_path = get_node("AimPath/PathFollow")
 
+# Speed
 @export var speed_multiplier = 1.0
 var speed = 0.2
 var did_click = false
 
+# Ranges
 enum RANGES {MISSED = 0, AVERAGE, GOOD, PERFECT}
 @onready var missed = get_node("Missed")
 @onready var average = get_node("Average")
@@ -58,8 +61,7 @@ func _unhandled_input(event) -> void:
         var points_won = get_overlapping_range()
 
         # TODO: remove this in favor of waiting on the animation
-
-
+        await get_tree().create_timer(1.0).timeout
         # Either update score or increased the missed count
         if points_won == 0:
             # TODO: Pause for a second to show some poor knife-throwing animation
@@ -74,6 +76,7 @@ func _unhandled_input(event) -> void:
             # TODO: play sfx
             # TODO: Eventually include a mood meter score multiplier?
             score += points_won
+            print("new score: " + str(score))
 
         # Go to the next round
         if current_round == MAX_ROUNDS:

--- a/jest-quest/scripts/mini_games/knife_throwing/knife_throwing.gd
+++ b/jest-quest/scripts/mini_games/knife_throwing/knife_throwing.gd
@@ -3,10 +3,19 @@ extends "res://scripts/mini_games/mini_game.gd"
 var game_name = "Knife-throwing"
 var game_description = "Throw knives at the target. The closer to the center, the more points you get."
 
+# Aim Bar
+@onready var aim_bar = get_node('AimPath/PathFollow/AimBar')
 @onready var aim_bar_path = get_node("AimPath/PathFollow")
 
 @export var speed_multiplier = 1.0
 var speed = 0.2
+enum RANGES {MISSED = 0, AVERAGE, GOOD, PERFECT}
+@onready var missed = get_node("Missed")
+@onready var average = get_node("Average")
+@onready var good = get_node("Good")
+@onready var perfect = get_node("Perfect")
+@onready var current_range = RANGES.MISSED
+
 
 func _process(delta) -> void:
     # Check how far along the path the aim bar is
@@ -16,3 +25,16 @@ func _process(delta) -> void:
         speed *= -1.0
     # Keep moving the aim bar along the path
     aim_bar_path.progress_ratio += speed * speed_multiplier * delta
+
+
+# Returns the range that the aim bar is overlapping
+func get_overlapping_range() -> RANGES:
+    var overlapping = aim_bar.get_overlapping_areas()
+    if overlapping.has(perfect):
+        return RANGES.PERFECT
+    elif overlapping.has(good):
+        return RANGES.GOOD
+    elif overlapping.has(average):
+        return RANGES.AVERAGE
+    return RANGES.MISSED
+

--- a/jest-quest/scripts/mini_games/knife_throwing/knife_throwing.gd
+++ b/jest-quest/scripts/mini_games/knife_throwing/knife_throwing.gd
@@ -31,89 +31,89 @@ enum RANGES {MISSED = 0, AVERAGE, GOOD, PERFECT}
 
 
 func _ready() -> void:
-    reset()
+	reset()
 
 
 # Reset the state of the mini-game
 func reset() -> void:
-    current_round = 1
-    n_missed = 0
-    score = 0
+	current_round = 1
+	n_missed = 0
+	score = 0
 
 
 func _process(delta) -> void:
-    # Check if user did click, return early if true
-    if did_click: return
+	# Check if user did click, return early if true
+	if did_click: return
 
-    # Check how far along the path the aim bar is
-    var progress_ratio = aim_bar_path.progress_ratio
-    if progress_ratio >= 1.0 or progress_ratio <= 0.0:
-        # Change the direction if we have hit the start or end of the path
-        speed *= -1.0
-    # Keep moving the aim bar along the path
-    aim_bar_path.progress_ratio += speed * speed_multiplier * delta
+	# Check how far along the path the aim bar is
+	var progress_ratio = aim_bar_path.progress_ratio
+	if progress_ratio >= 1.0 or progress_ratio <= 0.0:
+		# Change the direction if we have hit the start or end of the path
+		speed *= -1.0
+	# Keep moving the aim bar along the path
+	aim_bar_path.progress_ratio += speed * speed_multiplier * delta
 
 
 func _unhandled_input(event) -> void:
-    # Respond to mouse clicks anywhere in the window except for buttons
-    if event.is_action_pressed("left_mouse_button"):
-        did_click = true
-        var points_won = get_overlapping_range()
+	# Respond to mouse clicks anywhere in the window except for buttons
+	if event.is_action_pressed("left_mouse_button"):
+		did_click = true
+		var points_won = get_overlapping_range()
 
-        # TODO: remove this in favor of waiting on the animation
-        await get_tree().create_timer(1.0).timeout
-        # Either update score or increased the missed count
-        if points_won == 0:
-            # TODO: Pause for a second to show some poor knife-throwing animation
-            # TODO: play sfx
-            n_missed += 1
-            if n_missed == MAX_MISSED:
-                game_lost()
-                return
-        else:
-            # TODO: Pause for a second to show some knife-throwing animation
-            # and a change to the score
-            # TODO: play sfx
-            # TODO: Eventually include a mood meter score multiplier?
-            score += points_won
-            print("new score: " + str(score))
+		# TODO: remove this in favor of waiting on the animation
+		await get_tree().create_timer(1.0).timeout
+		# Either update score or increased the missed count
+		if points_won == 0:
+			# TODO: Pause for a second to show some poor knife-throwing animation
+			# TODO: play sfx
+			n_missed += 1
+			if n_missed == MAX_MISSED:
+				game_lost()
+				return
+		else:
+			# TODO: Pause for a second to show some knife-throwing animation
+			# and a change to the score
+			# TODO: play sfx
+			# TODO: Eventually include a mood meter score multiplier?
+			score += points_won
+			print("new score: " + str(score))
 
-        # Go to the next round
-        if current_round == MAX_ROUNDS:
-            game_won()
-        else:
-            next_round()
+		# Go to the next round
+		if current_round == MAX_ROUNDS:
+			game_won()
+		else:
+			next_round()
 
 
 # Returns the range that the aim bar is overlapping
 func get_overlapping_range() -> RANGES:
-    var overlapping = aim_bar.get_overlapping_areas()
-    if overlapping.has(perfect):
-        return RANGES.PERFECT
-    elif overlapping.has(good):
-        return RANGES.GOOD
-    elif overlapping.has(average):
-        return RANGES.AVERAGE
-    return RANGES.MISSED
+	var overlapping = aim_bar.get_overlapping_areas()
+	if overlapping.has(perfect):
+		return RANGES.PERFECT
+	elif overlapping.has(good):
+		return RANGES.GOOD
+	elif overlapping.has(average):
+		return RANGES.AVERAGE
+	return RANGES.MISSED
 
 
 func next_round() -> void:
-    # Increase the round number
-    current_round += 1
-    # Reset the aim bar position
-    # TODO: reset to either start or end, chosen at random
-    aim_bar_path.progress_ratio = 0.0
-    # Update the ranges
-    did_click = false
+	# Increase the round number
+	current_round += 1
+	# Reset the aim bar position
+	# TODO: reset to either start or end, chosen at random
+	aim_bar_path.progress_ratio = 0.0
+	# Update the ranges
+	did_click = false
 
 
 func game_lost() -> void:
-    # Display game lost animation
-    print("you lost :(")
-    failed()
+	# Display game lost animation
+	print("you lost :(")
+	failed()
 
 
 func game_won() -> void:
-    # Display game won animation
-    print("you won!")
-    finished()
+	# Display game won animation
+	print("you won!")
+	finished()

--- a/jest-quest/scripts/mini_games/knife_throwing/range_bar.gd
+++ b/jest-quest/scripts/mini_games/knife_throwing/range_bar.gd
@@ -1,0 +1,21 @@
+extends Area2D
+
+@export var width_scale = 1.0
+@export var color = Color(1, 1, 1, 1)
+
+# Components of the range bar
+@onready var color_rect = get_node('CollisionShape/Color')
+@onready var collision_shape = get_node('CollisionShape')
+
+func _ready() -> void:
+    # Set the color of the color rect to the color of the node
+    color_rect.color = color
+    # Set the width of the collision shape to the width scale of the node
+    update_width_scale(width_scale)
+
+
+func update_width_scale(new_width_scale) -> void:
+    # Update the width scale of the node
+    width_scale = new_width_scale
+    # Update the width of the collision shape
+    collision_shape.scale.x *= width_scale

--- a/jest-quest/scripts/mini_games/mini_game.gd
+++ b/jest-quest/scripts/mini_games/mini_game.gd
@@ -6,8 +6,8 @@ signal failure
 signal finish
 
 func finished():
-    emit_signal("finish")
+	emit_signal("finish")
 
 
 func failed():
-    emit_signal("failure")
+	emit_signal("failure")


### PR DESCRIPTION
Merging this PR will:

- Add a new knife-throwing mini-game.
- Support basic game mechanics by left-clicking.
- Support playing 5 rounds, but does not increase the difficulty (reserved for V2)
- Support keeping track of the player's score, but currently does nothing with overall game state (reserved for V2).
- Add basic range bars with simple graphics as placeholders.

To best make use of @ZedXC's mini-game class, we should first merge #4, before rebasing and merging any changes from this branch.

Closes #13.