### PR TITLE
Start Menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A game made while participating in GGJ 2024 via the Wellington, NZ jam site, aff
 
 ## Team Members
 
-- [Adam Goodyear](https://github.com/zedxc), Programmer, Pixel Artist, and Team Lead
+- [Adam Goodyear](https://github.com/zedxc), Programmer and Team Lead
 - [Josef Schultewolter](https://www.youtube.com/@Panda-wh8zk), Sound Designer and Audio Extraordinaire!
 - [Tessa Power](https://github.com/tessapower), Programmer and Project Manager
-- [Timothy Green](https://github.com/TFLGamer), Programmer and whatever tickles his fancy
+- [Timothy Green](https://github.com/TFLGamer), Artist
 
 ## Theme
 
@@ -21,7 +21,7 @@ TODO...
 
 ### Screenshots / Video
 
-TODO... 
+TODO...
 ❓Can we embed the game here??
 
 ### Description

--- a/jest-to-impress/project.godot
+++ b/jest-to-impress/project.godot
@@ -24,11 +24,6 @@ window/show_image=false
 
 [input]
 
-left_mouse_button={
-"deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
-]
-}
 LeftClick={
 "deadzone": 0.5,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)

--- a/jest-to-impress/project.godot
+++ b/jest-to-impress/project.godot
@@ -11,6 +11,7 @@ config_version=5
 [application]
 
 config/name="Jest to Impress"
+run/main_scene="res://scenes/ui/start_menu.tscn"
 config/features=PackedStringArray("4.2", "Forward Plus")
 config/icon="res://icon.svg"
 

--- a/jest-to-impress/scenes/ui/start_menu.tscn
+++ b/jest-to-impress/scenes/ui/start_menu.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=3 format=3 uid="uid://cr775t71eq8de"]
+[gd_scene load_steps=5 format=3 uid="uid://cr775t71eq8de"]
 
 [ext_resource type="Texture2D" uid="uid://b3fo2wqkwitp2" path="res://assets/graphics/SampleBackground.png" id="1_6wsac"]
+[ext_resource type="Script" path="res://scripts/ui/start_menu.gd" id="1_iq0sx"]
 [ext_resource type="FontFile" uid="uid://xc3r2otv1jqa" path="res://assets/graphics/Fonts/CartaMagna/Carta_Magna-line-demo-FFP.ttf" id="1_wqwh4"]
+[ext_resource type="PackedScene" uid="uid://bcb2f8o11jadh" path="res://scenes/ui/submenu.tscn" id="4_w43ci"]
 
 [node name="StartMenu" type="CanvasLayer"]
+script = ExtResource("1_iq0sx")
 
 [node name="TextureRect" type="TextureRect" parent="."]
 offset_right = 1920.0
@@ -38,57 +41,127 @@ alignment = 1
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
+focus_neighbor_bottom = NodePath("../HowToPlay")
+focus_next = NodePath("../HowToPlay")
 theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
 theme_override_fonts/font = ExtResource("1_wqwh4")
 theme_override_font_sizes/font_size = 38
-text = " Play Game "
+text = "Play Game"
 
-[node name="HowToPlay" type="MenuButton" parent="Content/Buttons"]
+[node name="HowToPlay" type="Button" parent="Content/Buttons"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
+focus_neighbor_top = NodePath("../Start")
+focus_neighbor_bottom = NodePath("../HighScores")
+focus_next = NodePath("../HighScores")
+focus_previous = NodePath("../Start")
+theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
 theme_override_fonts/font = ExtResource("1_wqwh4")
 theme_override_font_sizes/font_size = 38
-text = " How to Play "
-item_count = 1
-popup/item_0/text = ""
-popup/item_0/id = 0
+text = "How to Play"
 
-[node name="HighScores" type="MenuButton" parent="Content/Buttons"]
+[node name="Submenu" parent="Content/Buttons/HowToPlay" instance=ExtResource("4_w43ci")]
+handle_input_locally = false
+title = "How to Play!"
+visible = false
+text_content = "How to Play! 
+
+This is meant to show a bunch of text on the screen. Lorem ipsum sit dolor amet!"
+
+[node name="HighScores" type="Button" parent="Content/Buttons"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
+focus_neighbor_top = NodePath("../HowToPlay")
+focus_neighbor_bottom = NodePath("../Settings")
+focus_next = NodePath("../Settings")
+focus_previous = NodePath("../HowToPlay")
+theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
 theme_override_fonts/font = ExtResource("1_wqwh4")
 theme_override_font_sizes/font_size = 38
-text = " High Scores "
+text = "High Scores"
 
-[node name="Settings" type="MenuButton" parent="Content/Buttons"]
+[node name="Submenu" parent="Content/Buttons/HighScores" instance=ExtResource("4_w43ci")]
+visible = false
+text_content = "High scores will appear here when they are available and have implemented them."
+
+[node name="Settings" type="Button" parent="Content/Buttons"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
+focus_neighbor_top = NodePath("../HighScores")
+focus_neighbor_bottom = NodePath("../Credits")
+focus_next = NodePath("../Credits")
+focus_previous = NodePath("../HighScores")
+theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
 theme_override_fonts/font = ExtResource("1_wqwh4")
 theme_override_font_sizes/font_size = 38
-text = " Settings "
+text = "Settings"
 
-[node name="Credits" type="MenuButton" parent="Content/Buttons"]
+[node name="Submenu" parent="Content/Buttons/Settings" instance=ExtResource("4_w43ci")]
+visible = false
+text_content = "This is a placeholder submenu until we introduce the sound manager, and then we will have a settings submenu where the user can change the volume settings."
+
+[node name="Credits" type="Button" parent="Content/Buttons"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
+focus_neighbor_top = NodePath("../Settings")
+focus_neighbor_bottom = NodePath("../Exit")
+focus_next = NodePath("../Exit")
+focus_previous = NodePath("../Settings")
+theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
 theme_override_fonts/font = ExtResource("1_wqwh4")
 theme_override_font_sizes/font_size = 38
-text = " Credits "
+text = "Credits"
+
+[node name="Submenu" parent="Content/Buttons/Credits" instance=ExtResource("4_w43ci")]
+visible = false
+text_content = "Artwork: Timothy Green
+Music & SFX: Josef Schultewolter
+Programmers: Adam Goodyear, Tessa Power"
+
+[node name="Exit" type="Button" parent="Content/Buttons"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+focus_neighbor_top = NodePath("../Credits")
+focus_previous = NodePath("../Credits")
+theme_type_variation = &"FlatButton"
+theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
+theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_font_sizes/font_size = 38
+text = "Exit"
+
+[connection signal="pressed" from="Content/Buttons/Start" to="." method="_on_start_pressed"]
+[connection signal="pressed" from="Content/Buttons/HowToPlay" to="." method="_on_submenu_opened"]
+[connection signal="pressed" from="Content/Buttons/HowToPlay" to="Content/Buttons/HowToPlay/Submenu" method="_on_show"]
+[connection signal="close_requested" from="Content/Buttons/HowToPlay/Submenu" to="." method="_on_submenu_closed"]
+[connection signal="pressed" from="Content/Buttons/HighScores" to="." method="_on_submenu_opened"]
+[connection signal="pressed" from="Content/Buttons/HighScores" to="Content/Buttons/HighScores/Submenu" method="_on_show"]
+[connection signal="close_requested" from="Content/Buttons/HighScores/Submenu" to="." method="_on_submenu_closed"]
+[connection signal="pressed" from="Content/Buttons/Settings" to="." method="_on_submenu_opened"]
+[connection signal="pressed" from="Content/Buttons/Settings" to="Content/Buttons/Settings/Submenu" method="_on_show"]
+[connection signal="close_requested" from="Content/Buttons/Settings/Submenu" to="." method="_on_submenu_closed"]
+[connection signal="pressed" from="Content/Buttons/Credits" to="." method="_on_submenu_opened"]
+[connection signal="pressed" from="Content/Buttons/Credits" to="Content/Buttons/Credits/Submenu" method="_on_show"]
+[connection signal="close_requested" from="Content/Buttons/Credits/Submenu" to="." method="_on_submenu_closed"]
+[connection signal="pressed" from="Content/Buttons/Exit" to="." method="_on_exit_pressed"]

--- a/jest-to-impress/scenes/ui/start_menu.tscn
+++ b/jest-to-impress/scenes/ui/start_menu.tscn
@@ -1,0 +1,94 @@
+[gd_scene load_steps=3 format=3 uid="uid://cr775t71eq8de"]
+
+[ext_resource type="Texture2D" uid="uid://b3fo2wqkwitp2" path="res://assets/graphics/SampleBackground.png" id="1_6wsac"]
+[ext_resource type="FontFile" uid="uid://xc3r2otv1jqa" path="res://assets/graphics/Fonts/CartaMagna/Carta_Magna-line-demo-FFP.ttf" id="1_wqwh4"]
+
+[node name="StartMenu" type="CanvasLayer"]
+
+[node name="TextureRect" type="TextureRect" parent="."]
+offset_right = 1920.0
+offset_bottom = 1080.0
+scale = Vector2(0.599992, 0.600304)
+texture = ExtResource("1_6wsac")
+
+[node name="Content" type="VBoxContainer" parent="."]
+offset_right = 1152.0
+offset_bottom = 648.0
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/separation = 100
+alignment = 1
+
+[node name="Title" type="Label" parent="Content"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_font_sizes/font_size = 80
+text = "Jest to Impress"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Buttons" type="VBoxContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 8
+alignment = 1
+
+[node name="Start" type="Button" parent="Content/Buttons"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_type_variation = &"FlatButton"
+theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
+theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_font_sizes/font_size = 38
+text = " Play Game "
+
+[node name="HowToPlay" type="MenuButton" parent="Content/Buttons"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
+theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_font_sizes/font_size = 38
+text = " How to Play "
+item_count = 1
+popup/item_0/text = ""
+popup/item_0/id = 0
+
+[node name="HighScores" type="MenuButton" parent="Content/Buttons"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
+theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_font_sizes/font_size = 38
+text = " High Scores "
+
+[node name="Settings" type="MenuButton" parent="Content/Buttons"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
+theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_font_sizes/font_size = 38
+text = " Settings "
+
+[node name="Credits" type="MenuButton" parent="Content/Buttons"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
+theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_font_sizes/font_size = 38
+text = " Credits "

--- a/jest-to-impress/scenes/ui/submenu.tscn
+++ b/jest-to-impress/scenes/ui/submenu.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=3 format=3 uid="uid://bcb2f8o11jadh"]
+
+[ext_resource type="Script" path="res://scripts/ui/submenu.gd" id="1_6wa3a"]
+[ext_resource type="FontFile" uid="uid://xc3r2otv1jqa" path="res://assets/graphics/Fonts/CartaMagna/Carta_Magna-line-demo-FFP.ttf" id="2_tr4rq"]
+
+[node name="Submenu" type="Window"]
+initial_position = 1
+size = Vector2i(500, 400)
+borderless = true
+script = ExtResource("1_6wa3a")
+
+[node name="Content" type="VBoxContainer" parent="."]
+custom_minimum_size = Vector2(500, 400)
+offset_right = 500.0
+offset_bottom = 400.0
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/separation = 20
+alignment = 1
+
+[node name="TextContent" type="Label" parent="Content"]
+custom_minimum_size = Vector2(400, 200)
+layout_mode = 2
+size_flags_horizontal = 4
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 3
+
+[node name="Button" type="Button" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_fonts/font = ExtResource("2_tr4rq")
+theme_override_font_sizes/font_size = 28
+text = " Close "
+
+[connection signal="window_input" from="." to="." method="_on_window_input"]
+[connection signal="pressed" from="Content/Button" to="." method="_on_hide"]

--- a/jest-to-impress/scripts/mini_games/knife_throwing/knife_throwing.gd
+++ b/jest-to-impress/scripts/mini_games/knife_throwing/knife_throwing.gd
@@ -62,7 +62,7 @@ func _process(delta) -> void:
 
 func _unhandled_input(event) -> void:
 	# Respond to mouse clicks anywhere in the window except for buttons
-	if event.is_action_pressed("left_mouse_button"):
+	if event.is_action_pressed("LeftClick"):
 		did_click = true
 		var points_won = get_overlapping_range()
 

--- a/jest-to-impress/scripts/mini_games/knife_throwing/range_bar.gd
+++ b/jest-to-impress/scripts/mini_games/knife_throwing/range_bar.gd
@@ -9,6 +9,12 @@ extends Area2D
 @export var width_scale = 1.0
 @export var color = Color(1, 1, 1, 1)
 
+# range_bar.gd: This script handles the range bars used in the knife-throwing
+#               mini-game.
+#
+# Author(s): Tessa Power
+
+
 # Components of the range bar
 @onready var color_rect = get_node('CollisionShape/Color')
 @onready var collision_shape = get_node('CollisionShape')

--- a/jest-to-impress/scripts/ui/clicky_button.gd
+++ b/jest-to-impress/scripts/ui/clicky_button.gd
@@ -1,0 +1,14 @@
+extends Button
+
+@export_file var CLICK_SOUND
+var click_sound: AudioStream = null
+
+func _ready() -> void:
+    if CLICK_SOUND:
+        click_sound = load(CLICK_SOUND)
+
+func _on_pressed() -> void:
+    if click_sound:
+        print("click!")
+        # TODO: Add the Godot Sound Manager to handle playing audio & sfx
+        #SoundManager.play_ui_sound(click_sound)

--- a/jest-to-impress/scripts/ui/start_menu.gd
+++ b/jest-to-impress/scripts/ui/start_menu.gd
@@ -1,0 +1,25 @@
+extends CanvasLayer
+
+# start_menu.gd: This script handles responding to button being clicked and
+#                submenus opening/closing on the start menu.
+#
+# Author(s): Tessa Power
+
+@onready var buttons : Array = $Content/Buttons.get_children()
+
+func _on_start_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/game.tscn")
+
+
+func _on_exit_pressed() -> void:
+	get_tree().quit()
+
+
+func _on_submenu_opened() -> void:
+	for button in buttons:
+		button.disabled = true
+
+
+func _on_submenu_closed() -> void:
+	for button in buttons:
+		button.disabled = false

--- a/jest-to-impress/scripts/ui/start_menu.gd
+++ b/jest-to-impress/scripts/ui/start_menu.gd
@@ -5,6 +5,8 @@ extends CanvasLayer
 #
 # Author(s): Tessa Power
 
+# TODO: Ensure the submenus actually contain legitimate content
+
 @onready var buttons : Array = $Content/Buttons.get_children()
 
 func _on_start_pressed() -> void:

--- a/jest-to-impress/scripts/ui/submenu.gd
+++ b/jest-to-impress/scripts/ui/submenu.gd
@@ -1,0 +1,25 @@
+extends Window
+
+# submenu.gd: This script handles showing and hiding a submenu window intended
+#             to be used on the start menu.
+#
+# Author(s): Tessa Power
+
+@export_multiline var text_content : String = "Hello, this is a test"
+
+func _ready() -> void:
+	$Content/TextContent.set_text(text_content)
+
+
+func _on_show() -> void:
+	show()
+
+# This function enables the close button to hide the popup window.
+func _on_hide() -> void:
+	emit_signal("close_requested")
+	hide()
+
+
+func _on_window_input(event) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		_on_hide()


### PR DESCRIPTION
Merging this PR will:

- Create a submenu scene to be used with the start menu; the submenu has a script which handles showing and hiding the window popup in response to clicking the close button or if the escape key is pressed.
- Introduce a start menu scene with buttons that play the game, open submenus, and exit the game.
- Set the start menu as the starting scene for the project.
- Introduce a clicky button script which will later be used when SFX are available.
- Perform a minor tidy up.

Closes #6.