### PR TITLE
Gameover Screen

### DIFF
--- a/jest-to-impress/scenes/ui/game_over.tscn
+++ b/jest-to-impress/scenes/ui/game_over.tscn
@@ -1,0 +1,91 @@
+[gd_scene load_steps=5 format=3 uid="uid://xa8ipyyhywfs"]
+
+[ext_resource type="Script" path="res://scripts/ui/game_over.gd" id="1_lj07j"]
+[ext_resource type="Texture2D" uid="uid://b3fo2wqkwitp2" path="res://assets/graphics/SampleBackground.png" id="2_pybyx"]
+[ext_resource type="FontFile" uid="uid://cwdmo3e1666lq" path="res://assets/graphics/Fonts/PrinceValiant/PrinceValiant.ttf" id="3_01sk1"]
+[ext_resource type="FontFile" uid="uid://xc3r2otv1jqa" path="res://assets/graphics/Fonts/CartaMagna/Carta_Magna-line-demo-FFP.ttf" id="3_vcul6"]
+
+[node name="GameOver" type="Node2D"]
+script = ExtResource("1_lj07j")
+
+[node name="TextureRect" type="TextureRect" parent="."]
+offset_right = 1920.0
+offset_bottom = 1080.0
+scale = Vector2(0.599992, 0.600304)
+texture = ExtResource("2_pybyx")
+
+[node name="Content" type="VBoxContainer" parent="."]
+offset_right = 1152.0
+offset_bottom = 648.0
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/separation = 30
+alignment = 1
+
+[node name="Title" type="Label" parent="Content"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_vcul6")
+theme_override_font_sizes/font_size = 80
+text = "Game Over"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="FinalScore" type="Label" parent="Content"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_01sk1")
+theme_override_font_sizes/font_size = 60
+text = "Final Score:"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Buttons" type="VBoxContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 8
+alignment = 1
+
+[node name="PlayAgain" type="Button" parent="Content/Buttons"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+focus_neighbor_bottom = NodePath("../ReturnToStart")
+focus_next = NodePath("../ReturnToStart")
+theme_type_variation = &"FlatButton"
+theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
+theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_01sk1")
+theme_override_font_sizes/font_size = 38
+text = "Play Again"
+
+[node name="ReturnToStart" type="Button" parent="Content/Buttons"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+focus_neighbor_top = NodePath("../PlayAgain")
+focus_previous = NodePath("../PlayAgain")
+theme_type_variation = &"FlatButton"
+theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
+theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_01sk1")
+theme_override_font_sizes/font_size = 38
+text = "Return to Start Menu"
+
+[node name="Exit" type="Button" parent="Content/Buttons"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_type_variation = &"FlatButton"
+theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
+theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_01sk1")
+theme_override_font_sizes/font_size = 38
+text = "Exit"
+
+[connection signal="pressed" from="Content/Buttons/PlayAgain" to="." method="_on_play_again_pressed"]
+[connection signal="pressed" from="Content/Buttons/ReturnToStart" to="." method="_on_return_to_start_pressed"]
+[connection signal="pressed" from="Content/Buttons/Exit" to="." method="_on_exit_pressed"]

--- a/jest-to-impress/scenes/ui/start_menu.tscn
+++ b/jest-to-impress/scenes/ui/start_menu.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=5 format=3 uid="uid://cr775t71eq8de"]
+[gd_scene load_steps=6 format=3 uid="uid://cr775t71eq8de"]
 
 [ext_resource type="Texture2D" uid="uid://b3fo2wqkwitp2" path="res://assets/graphics/SampleBackground.png" id="1_6wsac"]
 [ext_resource type="Script" path="res://scripts/ui/start_menu.gd" id="1_iq0sx"]
 [ext_resource type="FontFile" uid="uid://xc3r2otv1jqa" path="res://assets/graphics/Fonts/CartaMagna/Carta_Magna-line-demo-FFP.ttf" id="1_wqwh4"]
+[ext_resource type="FontFile" uid="uid://cwdmo3e1666lq" path="res://assets/graphics/Fonts/PrinceValiant/PrinceValiant.ttf" id="4_b0cg7"]
 [ext_resource type="PackedScene" uid="uid://bcb2f8o11jadh" path="res://scenes/ui/submenu.tscn" id="4_w43ci"]
 
 [node name="StartMenu" type="CanvasLayer"]
@@ -19,7 +20,7 @@ offset_right = 1152.0
 offset_bottom = 648.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
-theme_override_constants/separation = 100
+theme_override_constants/separation = 40
 alignment = 1
 
 [node name="Title" type="Label" parent="Content"]
@@ -47,7 +48,7 @@ theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
-theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_fonts/font = ExtResource("4_b0cg7")
 theme_override_font_sizes/font_size = 38
 text = "Play Game"
 
@@ -63,7 +64,7 @@ theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
-theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_fonts/font = ExtResource("4_b0cg7")
 theme_override_font_sizes/font_size = 38
 text = "How to Play"
 
@@ -87,7 +88,7 @@ theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
-theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_fonts/font = ExtResource("4_b0cg7")
 theme_override_font_sizes/font_size = 38
 text = "High Scores"
 
@@ -107,7 +108,7 @@ theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
-theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_fonts/font = ExtResource("4_b0cg7")
 theme_override_font_sizes/font_size = 38
 text = "Settings"
 
@@ -127,7 +128,7 @@ theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
-theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_fonts/font = ExtResource("4_b0cg7")
 theme_override_font_sizes/font_size = 38
 text = "Credits"
 
@@ -147,7 +148,7 @@ theme_type_variation = &"FlatButton"
 theme_override_colors/font_color = Color(0.188235, 0.568627, 0.792157, 1)
 theme_override_colors/font_pressed_color = Color(0.67451, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
-theme_override_fonts/font = ExtResource("1_wqwh4")
+theme_override_fonts/font = ExtResource("4_b0cg7")
 theme_override_font_sizes/font_size = 38
 text = "Exit"
 

--- a/jest-to-impress/scripts/game.gd
+++ b/jest-to-impress/scripts/game.gd
@@ -18,6 +18,7 @@ func _ready():
 	mini_games.append(JUGGLING)
 	mini_games.append(KNIFE_THROWING)
 	load_mini_game(current_idx)
+	GamestateManager.reset()
 
 
 # Loads the mini-game at the given index and hooks it up to the appropriate
@@ -40,10 +41,11 @@ func unload_mini_game() -> void:
 
 # A callback function intended to be called by a mini-game when the player loses
 func on_failure() -> void:
-	# Decide whether or not to continue the game based on the mood meter
+	# Decide whether or not to continue the game based on the attention meter
 	if GamestateManager.is_game_over():
-		GamestateManager.reset()
-		# TODO: create a game over screen and load that
+		# TODO: display some game over animation?
+		# TODO: Stop the music
+		get_tree().change_scene_to_file("res://scenes/ui/game_over.tscn")
 	else:
 		print("Next mini-game!")
 		next_mini_game()

--- a/jest-to-impress/scripts/ui/game_over.gd
+++ b/jest-to-impress/scripts/ui/game_over.gd
@@ -1,0 +1,23 @@
+extends Node
+
+# game_over.gd: This script displays the player's final score on game over and
+#               responding to the player clicking any of the navigation buttons.
+#
+# Author(s): Tessa Power
+
+@onready var final_score_label = get_node("Content/FinalScore")
+
+func _ready() -> void:
+	final_score_label.text += "\n" + str(GamestateManager.score + 529)
+
+
+func _on_play_again_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/game.tscn")
+
+
+func _on_return_to_start_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/ui/start_menu.tscn")
+
+
+func _on_exit_pressed() -> void:
+	get_tree().quit()

--- a/jest-to-impress/scripts/ui/game_over.gd
+++ b/jest-to-impress/scripts/ui/game_over.gd
@@ -8,7 +8,7 @@ extends Node
 @onready var final_score_label = get_node("Content/FinalScore")
 
 func _ready() -> void:
-	final_score_label.text += "\n" + str(GamestateManager.score + 529)
+	final_score_label.text += "\n" + str(GamestateManager.score)
 
 
 func _on_play_again_pressed() -> void:


### PR DESCRIPTION
Merging this PR will:

- Add a new scene for a game over screen that shows the player their score in the game and includes buttons to play again, return to the start menu, or exit the game.
- Have the Game State Manager load the game over scene when the player loses.
- Tidy up the fonts and spacing on the start menu so it's more legible.

Closes #7.