### PR TITLE
Support High Scores

### DIFF
--- a/jest-to-impress/project.godot
+++ b/jest-to-impress/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 GamestateManager="*res://scripts/managers/gamestate_manager.gd"
+HighScoresManager="*res://scripts/managers/high_scores_manager.gd"
 
 [display]
 

--- a/jest-to-impress/scenes/ui/game_over.tscn
+++ b/jest-to-impress/scenes/ui/game_over.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://xa8ipyyhywfs"]
+[gd_scene load_steps=6 format=3 uid="uid://dugj2k0q86hy1"]
 
 [ext_resource type="Script" path="res://scripts/ui/game_over.gd" id="1_lj07j"]
 [ext_resource type="Texture2D" uid="uid://b3fo2wqkwitp2" path="res://assets/graphics/SampleBackground.png" id="2_pybyx"]
 [ext_resource type="FontFile" uid="uid://cwdmo3e1666lq" path="res://assets/graphics/Fonts/PrinceValiant/PrinceValiant.ttf" id="3_01sk1"]
 [ext_resource type="FontFile" uid="uid://xc3r2otv1jqa" path="res://assets/graphics/Fonts/CartaMagna/Carta_Magna-line-demo-FFP.ttf" id="3_vcul6"]
+[ext_resource type="PackedScene" uid="uid://d2ust2kqxaike" path="res://scenes/ui/high_score_entry.tscn" id="5_piy7r"]
 
 [node name="GameOver" type="Node2D"]
 script = ExtResource("1_lj07j")
@@ -36,7 +37,16 @@ layout_mode = 2
 theme_override_colors/font_color = Color(0.67451, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_01sk1")
 theme_override_font_sizes/font_size = 60
-text = "Final Score:"
+text = "Final Score: "
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="NewHighScore" type="Label" parent="Content"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.67451, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_01sk1")
+theme_override_font_sizes/font_size = 40
+text = "New High Score!"
 horizontal_alignment = 1
 vertical_alignment = 1
 
@@ -85,6 +95,9 @@ theme_override_colors/font_hover_color = Color(0.67451, 0, 0, 1)
 theme_override_fonts/font = ExtResource("3_01sk1")
 theme_override_font_sizes/font_size = 38
 text = "Exit"
+
+[node name="HighScoreEntry" parent="." instance=ExtResource("5_piy7r")]
+visible = false
 
 [connection signal="pressed" from="Content/Buttons/PlayAgain" to="." method="_on_play_again_pressed"]
 [connection signal="pressed" from="Content/Buttons/ReturnToStart" to="." method="_on_return_to_start_pressed"]

--- a/jest-to-impress/scenes/ui/high_score_entry.tscn
+++ b/jest-to-impress/scenes/ui/high_score_entry.tscn
@@ -1,0 +1,71 @@
+[gd_scene load_steps=3 format=3 uid="uid://d2ust2kqxaike"]
+
+[ext_resource type="Script" path="res://scripts/ui/high_score_entry.gd" id="1_54yt5"]
+[ext_resource type="FontFile" uid="uid://xc3r2otv1jqa" path="res://assets/graphics/Fonts/CartaMagna/Carta_Magna-line-demo-FFP.ttf" id="1_tih3e"]
+
+[node name="HighScoreEntry" type="Window"]
+initial_position = 2
+size = Vector2i(500, 400)
+exclusive = true
+unresizable = true
+borderless = true
+popup_window = true
+script = ExtResource("1_54yt5")
+
+[node name="Background" type="TextureRect" parent="."]
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="Content" type="VBoxContainer" parent="."]
+custom_minimum_size = Vector2(500, 400)
+offset_right = 500.0
+offset_bottom = 400.0
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/separation = 20
+alignment = 1
+
+[node name="Title" type="Label" parent="Content"]
+layout_mode = 2
+text = "New High Score!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="EnterName" type="Label" parent="Content"]
+layout_mode = 2
+text = "Enter your initials:"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="TextEntry" type="LineEdit" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 4
+placeholder_text = "ABC"
+alignment = 1
+max_length = 3
+clear_button_enabled = true
+shortcut_keys_enabled = false
+middle_mouse_paste_enabled = false
+drag_and_drop_selection_enabled = false
+caret_blink = true
+caret_force_displayed = true
+
+[node name="ErrorMessage" type="Label" parent="Content"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.878431, 0.298039, 0.298039, 1)
+theme_override_font_sizes/font_size = 14
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Submit" type="Button" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_fonts/font = ExtResource("1_tih3e")
+theme_override_font_sizes/font_size = 28
+disabled = true
+text = " Submit "
+
+[connection signal="text_changed" from="Content/TextEntry" to="." method="_on_line_edit_text_changed"]
+[connection signal="text_submitted" from="Content/TextEntry" to="." method="_on_line_edit_text_submitted"]
+[connection signal="pressed" from="Content/Submit" to="." method="_on_submit_pressed"]

--- a/jest-to-impress/scenes/ui/start_menu.tscn
+++ b/jest-to-impress/scenes/ui/start_menu.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://cr775t71eq8de"]
+[gd_scene load_steps=7 format=3 uid="uid://cr775t71eq8de"]
 
 [ext_resource type="Script" path="res://scripts/ui/start_menu.gd" id="1_iq0sx"]
 [ext_resource type="FontFile" uid="uid://xc3r2otv1jqa" path="res://assets/graphics/Fonts/CartaMagna/Carta_Magna-line-demo-FFP.ttf" id="1_wqwh4"]
 [ext_resource type="Texture2D" uid="uid://d5yjt1b3bha5" path="res://assets/graphics/Background.png" id="2_0pe6g"]
 [ext_resource type="Texture2D" uid="uid://ct5qlmrc27dwj" path="res://assets/graphics/King_Neutral.png" id="3_vsobi"]
 [ext_resource type="PackedScene" uid="uid://bcb2f8o11jadh" path="res://scenes/ui/submenu.tscn" id="4_w43ci"]
+[ext_resource type="Script" path="res://scripts/ui/high_scores_popup.gd" id="6_fq4fe"]
 
 [node name="StartMenu" type="CanvasLayer"]
 script = ExtResource("1_iq0sx")
@@ -138,10 +139,11 @@ theme_override_constants/outline_size = 10
 theme_override_fonts/font = ExtResource("1_wqwh4")
 theme_override_font_sizes/font_size = 38
 text = "High Scores"
+script = ExtResource("6_fq4fe")
 
 [node name="Submenu" parent="Content/Buttons/HighScores" instance=ExtResource("4_w43ci")]
 visible = false
-text_content = "High scores will appear here when they are available and have implemented them."
+text_content = "There are no high scores."
 
 [node name="Settings" type="Button" parent="Content/Buttons"]
 layout_mode = 2

--- a/jest-to-impress/scripts/game.gd
+++ b/jest-to-impress/scripts/game.gd
@@ -39,7 +39,6 @@ func load_mini_game(idx : int) -> void:
 
 # Unloads the current mini-game and disconnects the callback functions
 func unload_mini_game() -> void:
-	# We assume that the most recently added child is our mini-game
 	mini_game_instance.disconnect("failure", self.on_failure)
 	mini_game_instance.disconnect("finish", self.on_finished)
 	mini_game_instance.queue_free()

--- a/jest-to-impress/scripts/game.gd
+++ b/jest-to-impress/scripts/game.gd
@@ -53,7 +53,6 @@ func on_failure() -> void:
 		# TODO: Stop the music
 		get_tree().change_scene_to_file("res://scenes/ui/game_over.tscn")
 	else:
-		print("Next mini-game!")
 		next_mini_game()
 
 

--- a/jest-to-impress/scripts/managers/high_scores_manager.gd
+++ b/jest-to-impress/scripts/managers/high_scores_manager.gd
@@ -1,0 +1,63 @@
+extends Node
+
+# high_scores_manager.gd: Manages loading and saving high scores for the game.
+#
+# Author(s): Tessa Power
+
+# High Scores Data
+var high_scores: Array = []
+const HS_FILEPATH = "user://high_scores.tres"
+var high_scores_data = HighScores.new()
+const MAX_SCORES = 10
+
+func _ready() -> void:
+	load_from_disk()
+
+
+# Update the list of high scores, which are kept in sorted order from highest
+# to lowest.
+func update_high_scores(player_name : String, high_score : int) -> void:
+	high_scores.append([player_name, high_score])
+	sort_high_scores()
+
+
+# Sorts the high scores in descending order.
+func sort_high_scores() -> void:
+	# Create a deep copy of the high scores
+	var sorted = high_scores.duplicate(true)
+	# Sort the high scores in descending order by comparing the scores
+	sorted.sort_custom(func(a, b): return a[1] > b[1])
+	# Only keep the top 10 high scores
+	sorted.slice(0, MAX_SCORES, 1, true)
+	high_scores = sorted.duplicate(true)
+
+# Saves the high scores to disk. This function should ideally only be called
+# right before exiting the game (using _exit_tree()) to avoid too many costly
+# writes to disk.
+func save_to_disk() -> void:
+	ResourceSaver.save(high_scores_data, HS_FILEPATH)
+
+
+# Returns whether the given score is considered a high score. This function
+# should ideally be used to assess whether or not to show the high score name
+# entry after the game ends.
+func is_high_score(score : int) -> bool:
+	# Compare the given score to the lowest high score
+	return score >= high_scores.back() if not high_scores.is_empty() else true
+
+
+# Loads the high scores from disk. This function should ideally only be called
+# once at start up to avoid costly reads from disk and more importatnly
+# overwriting any new high scores achieved while the game is running.
+func load_from_disk():
+	if FileAccess.file_exists(HS_FILEPATH):
+		high_scores_data = ResourceLoader.load(HS_FILEPATH).duplicate(true)
+		high_scores = high_scores_data.high_scores
+	else:
+		printerr("No save file found at path!")
+		print("Creating new save file...")
+		save_to_disk()
+
+
+func _exit_tree() -> void:
+	save_to_disk()

--- a/jest-to-impress/scripts/managers/high_scores_manager.gd
+++ b/jest-to-impress/scripts/managers/high_scores_manager.gd
@@ -12,6 +12,7 @@ const MAX_SCORES = 10
 
 func _ready() -> void:
 	load_from_disk()
+	sort_high_scores()
 
 
 # Update the list of high scores, which are kept in sorted order from highest
@@ -30,6 +31,7 @@ func sort_high_scores() -> void:
 	# Only keep the top 10 high scores
 	sorted.slice(0, MAX_SCORES, 1, true)
 	high_scores = sorted.duplicate(true)
+
 
 # Saves the high scores to disk. This function should ideally only be called
 # right before exiting the game (using _exit_tree()) to avoid too many costly
@@ -53,6 +55,9 @@ func load_from_disk():
 	if FileAccess.file_exists(HS_FILEPATH):
 		high_scores_data = ResourceLoader.load(HS_FILEPATH).duplicate(true)
 		high_scores = high_scores_data.high_scores
+		# ⚠️ FOR DEVELOPMENT PURPOSES ONLY! ⚠️
+		# Uncomment this to clear highscores.
+		#high_scores.clear()
 	else:
 		printerr("No save file found at path!")
 		print("Creating new save file...")

--- a/jest-to-impress/scripts/managers/high_scores_manager.gd
+++ b/jest-to-impress/scripts/managers/high_scores_manager.gd
@@ -43,7 +43,7 @@ func save_to_disk() -> void:
 # entry after the game ends.
 func is_high_score(score : int) -> bool:
 	# Compare the given score to the lowest high score
-	return score >= high_scores.back() if not high_scores.is_empty() else true
+	return score >= high_scores.back()[1] if not high_scores.is_empty() else true
 
 
 # Loads the high scores from disk. This function should ideally only be called

--- a/jest-to-impress/scripts/ui/game_over.gd
+++ b/jest-to-impress/scripts/ui/game_over.gd
@@ -5,10 +5,20 @@ extends Node
 #
 # Author(s): Tessa Power
 
-@onready var final_score_label = get_node("Content/FinalScore")
+@onready var final_score = get_node("Content/FinalScore")
+@onready var new_high_score = get_node("Content/NewHighScore")
 
 func _ready() -> void:
-	final_score_label.text += "\n" + str(GamestateManager.score)
+	var score = GamestateManager.score
+	# Update the text to display the final score
+	final_score.text += str(score)
+	# Check if we got a high score
+	if HighScoresManager.is_high_score(score) and score > 0:
+		# TODO: Play some happy triumphant sound?
+		# Show the new high score entry popup
+		$HighScoreEntry.show()
+	else:
+		new_high_score.set_text("")
 
 
 func _on_play_again_pressed() -> void:

--- a/jest-to-impress/scripts/ui/high_score_entry.gd
+++ b/jest-to-impress/scripts/ui/high_score_entry.gd
@@ -1,0 +1,55 @@
+extends Window
+
+@onready var text_entry = $Content/TextEntry
+@onready var submit_button = $Content/Submit
+@onready var error_msg = $Content/ErrorMessage
+const ERROR_TEXT : String = "Please only use letters A - Z"
+@onready var max_len = text_entry.max_length
+@onready var regex = RegEx.new()
+
+func _ready():
+	text_entry.clear()
+	text_entry.grab_focus()
+
+	submit_button.disabled = true
+	# We only support entering alphabetic characters
+	regex.compile("[^A-Za-z]")
+
+
+func _on_line_edit_text_changed(new_text):
+	# Don't do anything if the text field is empty
+	if new_text == "":
+		submit_button.disabled = true
+		return
+
+	# Enable the submit button if the new text isn't an empty string
+	if is_text_valid(new_text):
+		submit_button.disabled = false
+		error_msg.set_text("")
+	else:
+		submit_button.disabled = true
+
+
+func _on_line_edit_text_submitted(new_text):
+	if new_text != "":
+		if is_text_valid(new_text):
+			# Add to the highscores
+			HighScoresManager.update_high_scores(new_text, GamestateManager.score)
+			# Clear the text entry field
+			text_entry.clear()
+			# Hide the popup window
+			hide()
+		else:
+			error_msg.set_text(ERROR_TEXT)
+	else:
+		submit_button.disabled = true
+
+
+func _on_submit_pressed():
+	_on_line_edit_text_submitted(text_entry.text)
+
+
+func is_text_valid(text) -> bool:
+	var illegal_chars = regex.search(text)
+
+	return false if illegal_chars else true

--- a/jest-to-impress/scripts/ui/high_score_entry.gd
+++ b/jest-to-impress/scripts/ui/high_score_entry.gd
@@ -1,5 +1,11 @@
 extends Window
 
+# high_score_entry.gd: A popup that allows players to enter their initials when
+#                      they get a high score. Will handle adding the score to
+#                      the leaderboard.
+#
+# Author(s): Tessa Power
+
 @onready var text_entry = $Content/TextEntry
 @onready var submit_button = $Content/Submit
 @onready var error_msg = $Content/ErrorMessage

--- a/jest-to-impress/scripts/ui/high_scores_popup.gd
+++ b/jest-to-impress/scripts/ui/high_scores_popup.gd
@@ -1,0 +1,18 @@
+extends Node
+
+# high_scores_popup.gd: Reads the high scores and creates a list to display in
+#                       the popup on the start menu.
+#
+# Author(s): Tessa Power
+
+func _ready():
+	var list = scores_to_list(HighScoresManager.high_scores)
+	$Submenu/Content/TextContent.set_text(list)
+
+func scores_to_list(scores : Array) -> String:
+	if scores.is_empty(): return "There are no high scores."
+
+	var list = ""
+	for score in scores:
+		list += score[0] + " \t " + str(score[1]) + "\n"
+	return list

--- a/jest-to-impress/scripts/utils/high_scores.gd
+++ b/jest-to-impress/scripts/utils/high_scores.gd
@@ -1,0 +1,7 @@
+class_name HighScores extends Resource
+
+@export var high_scores: Array
+
+# high_scores.gd: A custom resource for saving high scores to disk.
+#
+# Author(s): Tessa Power


### PR DESCRIPTION
Merging this PR will:

- Add support for tracking high scores.
- Add a new popup for entering the player's name when the game is over and they got a new high score. 
- Populate the high scores popup on the start menu, if there are any.

Closes #9.